### PR TITLE
Restrict publishing only on merge event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ on:
     branches: [ main ]
     tags-ignore:
       - '**'
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Currently, the `publish action` job runs on every pull request creation and update, which is unnecessary. The workflow should only be triggered after a pull request is successfully merged into the `main` branch.